### PR TITLE
Add html tag in default layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,3 +1,6 @@
+<!doctype html>
+<html>
+
 {% include head.html %}
 
 <body>
@@ -14,3 +17,4 @@
   </div>
 
 </body>
+</html>


### PR DESCRIPTION
There is no html tag in the default layout. I believe it's not intentional?