### PR TITLE
Inline author info to give the credit to template author

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,5 +4,5 @@
   <a href="https://instagram.com/{{site.author.instagram}}"><i class="fa fa-instagram" aria-hidden="true" target="_blank"></i></a>
   <a href="https://linkedin.com/in/{{site.author.linkedin}}"><i class="fa fa-linkedin" aria-hidden="true" target="_blank"></i></a>
   <a href="mailto:{{site.author.email}}"><i class="fa fa-envelope" aria-hidden="true" target="_blank"></i></a>
-  <div class="post-date"><a href="{{ site.github.url }}/menu/about.html">{{ site.title }} | {{ site.tagline }} by {{ site.author.name }}</a></div>
+  <div class="post-date"><a href="https://lenpaul.github.io/Lagrange/menu/about.html">Lagrange | a minimalist Jekyll theme by Paul Le</a></div>
 </footer>


### PR DESCRIPTION
I don't know whether it was an intentional decision or not, but since you used author variable, the footer credit will be overwritten by client info.

Since I happily used your work, I wanted to credit theme author, because you know, "you got to give credit where credit is due"!

If you don't need such kind of attribution then it's more than fine too!