### PR TITLE
Updated head.html to add meta tag which defines utf8 charset

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,6 +9,7 @@
   </title>
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta charset="utf-8">
 
   <link rel="stylesheet" href="{{ site.github.url }}/assets/css/main.css">
   <link rel="stylesheet" href="{{ site.github.url }}/assets/css/syntax.css">


### PR DESCRIPTION
In my case blog posts which contained a single apostrophe would freak out and spew out gibberish for some reason. I got it fixed by adding an utf8 encoding as a meta tag in head.html