### PR TITLE
Updated mathjax cdn

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -24,10 +24,7 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Quattrocento+Sans">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 
-  <script type="text/javascript" async
-    src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML">
-  </script>
-
+  <script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.3/MathJax.js?config=TeX-MML-AM_CHTML' async></script>
   <!-- Google Analytics -->
   {% include google-analytics.html %}
 


### PR DESCRIPTION
Updated mathjax cdn to recommended one(seen [here](https://www.mathjax.org/cdn-shutting-down/)).

Updated due to this [warning](https://i.imgur.com/zHYBsgQ.png)