### PR TITLE
Adding workaround to horizontal overflow code

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -299,6 +299,12 @@ pre code {
   background-color: transparent;
 }
 
+/* Horizontal code overflow fix */
+pre.highlight {
+  white-space: pre;
+  overflow-x: auto;
+}
+
 /* Pygments via Jekyll */
 .highlight {
   margin-bottom: 1rem;


### PR DESCRIPTION
Sometimes the code is too long to fit in a code box, where they just tend to break lines, destroying the original layout of code. This should fix the problem, though still a workaround.

The before and after:
<details>
<summary>Before</summary>

![before](https://user-images.githubusercontent.com/7822648/52179016-16e1df00-2810-11e9-996f-3636df248640.png)
</details>

<details>
<summary>After</summary>

![after](https://user-images.githubusercontent.com/7822648/52179019-23663780-2810-11e9-9cd2-1e8ca4acad0b.png)
</details>
