### PR TITLE
Removing Google+ in social sharing

### DIFF
--- a/_includes/social-sharing.html
+++ b/_includes/social-sharing.html
@@ -2,6 +2,5 @@
   <div class="sharing-icons">
     <a href="https://twitter.com/intent/tweet?text={{ page.title }}&amp;url={{ site.github.url }}{{ page.url }}" target="_blank"><i class="fa fa-twitter" aria-hidden="true"></i></a>
     <a href="https://www.facebook.com/sharer/sharer.php?u={{ site.github.url }}{{ page.url }}&amp;title={{ page.title }}" target="_blank"><i class="fa fa-facebook" aria-hidden="true"></i></a>
-    <a href="https://plus.google.com/share?url={{ site.github.url }}{{ page.url }}" target="_blank"><i class="fa fa-google-plus" aria-hidden="true"></i></a>
   </div>
 </div>


### PR DESCRIPTION
Google+ discontinued its service to customers