### PR TITLE
Added site.baseurl for cases where site is served from sub-directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Gemfile.lock
 .jekyll-metadata
 .DS_Store
 .jekyll-cache
+.idea/

--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,12 @@ title:		           'Lagrange'
 description:	       'a minimalist Jekyll theme'
 author:              'Paul Le'
 
+# URL settings
+url:  # Root of the domain. Full URL including protocol, domain, and port (if applicable), e.g., https://example.com
+
+# baseurl is optional: Name of sub-directory where the site is served from, e.g., in https://example.com/Lagrange
+baseurl: /Lagrange # comment this line if the site lives at the root of the domain
+
 # RSS 2.0 can be used instead of Atom by uncommenting following two lines
 #feed:
 #  path: rss-feed.xml

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,4 @@
 <footer class="footer">
   {% include social-icons.html %}
-  <div class="footer-description"><a href="{{ site.github.url }}/">{{ site.title }} | {{ site.description }} by {{ site.author }}</a></div>
+  <div class="footer-description"><a href="{{ site.url }}{{ site.baseurl }}/">{{ site.title }} | {{ site.description }} by {{ site.author }}</a></div>
 </footer>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,12 +8,12 @@
   </title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta charset="utf-8">
-  <link rel="stylesheet" href="{{ site.github.url }}/assets/css/main.css">
-  <link rel="stylesheet" href="{{ site.github.url }}/assets/css/syntax.css">
+  <link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/assets/css/main.css">
+  <link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/assets/css/syntax.css">
   <!-- Use Atom -->
   {% feed_meta %}
   <!-- Use RSS-2.0 -->
-  <!--<link href="{{ site.github.url }}/rss-feed.xml" type="application/rss+xml" rel="alternate" title="{{ site.title }} | {{ site.description }}"/>
+  <!--<link href="{{ site.url }}{{ site.baseurl }}/rss-feed.xml" type="application/rss+xml" rel="alternate" title="{{ site.title }} | {{ site.description }}"/>
   //-->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Serif:400,400italic,700%7CPT+Sans:400">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Code+Pro">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,6 +1,6 @@
 <header class="header">
   <h3 class="header-title">
-    <a href="{{ site.github.url }}/">{{ site.title }}</a>
+    <a href="{{ site.url }}{{ site.baseurl }}/">{{ site.title }}</a>
     <small class="header-subtitle">{{ site.description }}</small>
     {% include menu.html %}
   </h3>

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -1,7 +1,7 @@
 <div class="menu">
   <nav class="menu-content">
     {% for item in site.data.settings.menu %}
-      <a href="{{ site.github.url }}/{{ item.url }}">{{ item.name }}</a>
+      <a href="{{ site.url }}{{ site.baseurl }}/{{ item.url }}">{{ item.name }}</a>
     {% endfor %}
   </nav>
   <nav class="social-icons">

--- a/_includes/related-posts.html
+++ b/_includes/related-posts.html
@@ -8,7 +8,7 @@
         {% else %}
           <li>
             <h3>
-              <a href="{{ site.github.url }}{{ mypost.url }}">
+              <a href="{{ site.url }}{{ site.baseurl }}{{ mypost.url }}">
                 {{ mypost.title }}
                 <!--<img src="{{ site.url }}{{ site.baseurl }}/images/{{ mypost.image.teaser }}">-->
                 <!--<small>{{ mypost.date | date: "%B %-d, %Y" }}</small>-->

--- a/_includes/social-sharing.html
+++ b/_includes/social-sharing.html
@@ -1,5 +1,5 @@
 <div class="post-date">{{ site.data.settings.sharing_button_prompt }}</div>
 <div class="sharing-icons">
-  <a href="https://twitter.com/intent/tweet?text={{ page.title }}&amp;url={{ site.github.url }}{{ page.url }}" target="_blank"><i class="fa fa-twitter" aria-hidden="true"></i></a>
-  <a href="https://www.facebook.com/sharer/sharer.php?u={{ site.github.url }}{{ page.url }}&amp;title={{ page.title }}" target="_blank"><i class="fa fa-facebook" aria-hidden="true"></i></a>
+	<a href="https://twitter.com/intent/tweet?text={{ page.title }}&amp;url={{ site.url }}{{ site.baseurl }}{{ page.url }}" target="_blank"><i class="fa fa-twitter" aria-hidden="true"></i></a>
+	<a href="https://www.facebook.com/sharer/sharer.php?u={{ site.url }}{{ site.baseurl }}{{ page.url }}&amp;title={{ page.title }}" target="_blank"><i class="fa fa-facebook" aria-hidden="true"></i></a>
 </div>

--- a/_layouts/archive.html
+++ b/_layouts/archive.html
@@ -18,7 +18,7 @@ layout: default
       {% endif %}
     {% endunless %}
     <li itemscope>
-      <a href="{{ site.github.url }}{{ post.url }}">{{ post.title }}</a>
+      <a href="{{ site.url }}{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a>
       <p class="post-date"><span><i class="fa fa-calendar" aria-hidden="true"></i> {{ post.date | date: "%B %-d" }} - <i class="fa fa-clock-o" aria-hidden="true"></i> {% include read-time.html %}</span></p>
     </li>
   {% endfor %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -5,15 +5,15 @@ layout: default
 {% for post in paginator.posts %}
   <div class="posts-container">
     <h1>
-      <a href="{{ site.github.url }}{{ post.url }}">{{ post.title }}</a>
+      <a href="{{ site.url }}{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a>
     </h1>
     {% if post.image %}
       <div class="thumbnail-container">
-        <a href="{{ site.github.url }}{{ post.url }}"><img src="{{ site.github.url }}/assets/img/{{ post.image }}"></a>
+        <a href="{{ site.url }}{{ site.baseurl }}{{ post.url }}"><img src="{{ site.url }}{{ site.baseurl }}/assets/img/{{ post.image }}"></a>
       </div>
     {% endif %}
     <p>
-      {{ post.content | strip_html | truncate: 350 }} <a href="{{ site.github.url }}{{ post.url }}">Read more</a>
+      {{ post.content | strip_html | truncate: 350 }} <a href="{{ site.url }}{{ site.baseurl }}{{ post.url }}">Read more</a>
       <span class="post-date"><i class="fa fa-calendar" aria-hidden="true"></i> {{ post.date | date_to_string }} - <i class="fa fa-clock-o" aria-hidden="true"></i> {% include read-time.html %}</span>
     </p>
   </div>
@@ -21,7 +21,7 @@ layout: default
 <!-- Pagination links -->
 <div class="pagination">
   {% if paginator.next_page %}
-    <a class="pagination-button pagination-active next" href="{{ site.github.url }}{{ paginator.next_page_path }}">{{ site.data.settings.pagination.previous_page }}</a>
+    <a class="pagination-button pagination-active next" href="{{ site.url }}{{ site.baseurl }}{{ paginator.next_page_path }}">{{ site.data.settings.pagination.previous_page }}</a>
   {% else %}
     <span class="pagination-button">{{ site.data.settings.pagination.previous_page }}</span>
   {% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,7 +6,7 @@ layout: default
   {{ page.title }}
 </h1>
 {% if page.image %}
-  <img src="{{ site.github.url }}/assets/img/{{ page.image }}">
+  <img src="{{ site.url }}{{ site.baseurl }}/assets/img/{{ page.image }}">
 {% endif %}
 <article>
   {{ content }}

--- a/_posts/2016-01-01-welcome-to-lagrange.md
+++ b/_posts/2016-01-01-welcome-to-lagrange.md
@@ -11,11 +11,11 @@ Lagrange is a minimalist Jekyll theme. The purpose of this theme is to provide a
 
 ## Getting Started
 
-[Getting Started]({{ site.github.url }}{% post_url 2015-10-10-getting-started %}): getting started with installing Lagrange, whether you are completely new to using Jekyll, or simply just migrating to a new Jekyll theme.
+[Getting Started]({% post_url 2015-10-10-getting-started %}): getting started with installing Lagrange, whether you are completely new to using Jekyll, or simply just migrating to a new Jekyll theme.
 
 ## Example Content
 
-[Text and Formatting]({{ site.github.url }}{% post_url 2014-01-01-text-formatting-examples %})
+[Text and Formatting]({% post_url 2014-01-01-text-formatting-examples %})
 
 ## Questions?
 

--- a/menu/about.md
+++ b/menu/about.md
@@ -8,11 +8,11 @@ Lagrange is a minimalist Jekyll theme. The purpose of this theme is to provide a
 
 ### Getting Started
 
-[Getting Started]({{ site.github.url }}{% post_url 2015-10-10-getting-started %}): getting started with installing Lagrange, whether you are completely new to using Jekyll, or simply just migrating to a new Jekyll theme.
+[Getting Started]({% post_url 2015-10-10-getting-started %}): getting started with installing Lagrange, whether you are completely new to using Jekyll, or simply just migrating to a new Jekyll theme.
 
 ### Example Content
 
-[Text and Formatting]({{ site.github.url }}{% post_url 2014-01-01-text-formatting-examples %})
+[Text and Formatting]({% post_url 2014-01-01-text-formatting-examples %})
 
 ### Questions?
 

--- a/rss-feed.xml
+++ b/rss-feed.xml
@@ -5,8 +5,8 @@
 	<channel>
 		<title>{{ site.title | xml_escape }}</title>
 		<description>{% if site.description %}{{ site.description | xml_escape }}{% endif %}</description>
-		<link>{{ site.github.url }}</link>
-		<atom:link href="{{ site.github.url }}/{{ page.path }}" rel="self" type="application/rss+xml" />
+		<link>{{ site.url }}{{ site.baseurl }}</link>
+		<atom:link href="{{ site.url }}{{ site.baseurl }}/{{ page.path }}" rel="self" type="application/rss+xml" />
 		{% for post in site.posts limit:10 %}
 			<item>
 				<title>{{ post.title | xml_escape }}</title>


### PR DESCRIPTION
- Added `baseurl` as in `{{ site.url }}{{ site.baseurl }}` to prepend to the url. 
- `url` and `baseurl` are specified in _config.yml, where:
    - `url`: Root of the domain, including protocol, domain, and port (if applicable), e.g., https://example.com
    - `baseurl`: Optional. Name of sub-directory where the site is served from, e.g., `/Lagrange` in https://example.com/Lagrange