### PR TITLE
Prevent floating elements overlap by adding clear: both;

### DIFF
--- a/_sass/_default.scss
+++ b/_sass/_default.scss
@@ -25,12 +25,17 @@
 */
 
 .header {
-  clear: both;
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
   margin-bottom: 4rem;
   font-family: $sans-serif-font-family;
 }
+
+header::after {
+  content: "";
+  display: block;
+  clear: both;
+};
 
 .header a:hover {
   color:black;

--- a/_sass/_default.scss
+++ b/_sass/_default.scss
@@ -25,6 +25,7 @@
 */
 
 .header {
+  clear: both;
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
   margin-bottom: 4rem;


### PR DESCRIPTION
The social-icons in the header may overlap with the title of the posts' h1 tag. This patch ensures that the overlap does not happen.

This screenshot shows what happens without this patch on smaller screens:

![Screenshot-2024-09-11:01:22:37](https://github.com/user-attachments/assets/59a5ee66-1c33-4c0d-9871-a56b1c221ab1)
