### PR TITLE
Introduce automatic recognition of internal or external links to the menu setting

### DIFF
--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -1,7 +1,11 @@
 <div class="menu">
   <nav class="menu-content">
     {% for item in site.data.settings.menu %}
-      <a href="{{ site.github.url }}/{{ item.url }}">{{ item.name }}</a>
+      {% if item.url contains "://" or item.url contains "mailto:" or item.url contains "tel:" %}
+        <a href="{{ item.url }}">{{ item.name }}</a>
+      {% else %}
+        <a href="{{ site.github.url }}/{{ item.url }}">{{ item.name }}</a>
+      {% endif %}
     {% endfor %}
   </nav>
   <nav class="social-icons">


### PR DESCRIPTION
## Why Submit this change?

Take myself as an example. When I want a certain item in the menu to directly redirect to another site of mine, I encounter an error because this statement (`<a href="{{ site.github.url }}/{{ item.url }}">{{ item.name }}</a>`) causes my external link to be embedded behind the link of this site ({{ site.github.url }}).

## How this change work?

Just a simple judgment statement was added to determine whether it meets the requirement of containing a specific string, thereby adjusting the redirection statement.

## What will this change bring?

Users can directly jump to the external link (or send an email) they want by clicking the menu.

---

The schematic code is as follows:

```yml
menu:
- {name: 'About', url: 'about.html'} # Visit the about page within the site
- {name: 'GitHub', url: 'https://github.com/'} # Redirect to the external link
```
